### PR TITLE
Support custom FileSystem; prevent FileChannel, use SeekableByteChannel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /misc/
 /build/
 *~
+/bin

--- a/src/main/com/github/perlundq/yajsync/io/CustomFileSystem.java
+++ b/src/main/com/github/perlundq/yajsync/io/CustomFileSystem.java
@@ -1,0 +1,47 @@
+/*
+ * Processing of incoming file lists and file data from Sender
+ *
+ * Copyright (C) 1996-2011 by Andrew Tridgell, Wayne Davison, and others
+ * Copyright (C) 2013, 2014 Per Lundqvist
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.perlundq.yajsync.io;
+
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+
+public class CustomFileSystem {
+
+	private static FileSystem _filesystem = FileSystems.getDefault();
+	private static FileSystem _tempFilesystem = FileSystems.getDefault();
+
+	public static void setFileSystem(FileSystem filesystem) {
+		_filesystem = filesystem;
+	}
+	
+	public static void setTempFileSystem(FileSystem tempFilesystem) {
+		_tempFilesystem = tempFilesystem;
+	}
+
+	public static Path getPath(String path) {
+		return _filesystem.getPath(path);
+	}
+	
+	public static Path getTempPath(String path) {
+		return _tempFilesystem.getPath(path);
+	}
+}

--- a/src/main/com/github/perlundq/yajsync/io/CustomFileSystem.java
+++ b/src/main/com/github/perlundq/yajsync/io/CustomFileSystem.java
@@ -1,8 +1,9 @@
 /*
- * Processing of incoming file lists and file data from Sender
+ * Configurable FileSystem implementations
  *
  * Copyright (C) 1996-2011 by Andrew Tridgell, Wayne Davison, and others
  * Copyright (C) 2013, 2014 Per Lundqvist
+ * Copyright (C) 2014 Florian Sager
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,10 +28,15 @@ import java.nio.file.Path;
 public class CustomFileSystem {
 
 	private static FileSystem _filesystem = FileSystems.getDefault();
+	private static FileSystem _configFilesystem = FileSystems.getDefault();
 	private static FileSystem _tempFilesystem = FileSystems.getDefault();
 
 	public static void setFileSystem(FileSystem filesystem) {
 		_filesystem = filesystem;
+	}
+	
+	public static void setConfigFileSystem(FileSystem configFilesystem) {
+		_configFilesystem = configFilesystem;
 	}
 	
 	public static void setTempFileSystem(FileSystem tempFilesystem) {
@@ -40,7 +46,11 @@ public class CustomFileSystem {
 	public static Path getPath(String path) {
 		return _filesystem.getPath(path);
 	}
-	
+
+	public static Path getConfigPath(String path) {
+		return _configFilesystem.getPath(path);
+	}
+
 	public static Path getTempPath(String path) {
 		return _tempFilesystem.getPath(path);
 	}

--- a/src/main/com/github/perlundq/yajsync/session/RsyncClientSession.java
+++ b/src/main/com/github/perlundq/yajsync/session/RsyncClientSession.java
@@ -23,11 +23,11 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import com.github.perlundq.yajsync.io.CustomFileSystem;
 import com.github.perlundq.yajsync.session.ClientSessionConfig.AuthProvider;
 import com.github.perlundq.yajsync.text.Text;
 
@@ -143,7 +143,7 @@ public class RsyncClientSession
     {
         List<Path> result = new LinkedList<>();
         for (String pathName : pathNames) {
-            result.add(Paths.get(pathName));
+            result.add(CustomFileSystem.getPath(pathName));
         }
         return result;
     }

--- a/src/main/com/github/perlundq/yajsync/session/Sender.java
+++ b/src/main/com/github/perlundq/yajsync/session/Sender.java
@@ -29,7 +29,6 @@ import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.logging.Level;
@@ -46,6 +45,7 @@ import com.github.perlundq.yajsync.channels.RsyncOutChannel;
 import com.github.perlundq.yajsync.filelist.FileInfo;
 import com.github.perlundq.yajsync.filelist.Filelist;
 import com.github.perlundq.yajsync.filelist.RsyncFileAttributes;
+import com.github.perlundq.yajsync.io.CustomFileSystem;
 import com.github.perlundq.yajsync.io.FileView;
 import com.github.perlundq.yajsync.io.FileViewNotFound;
 import com.github.perlundq.yajsync.io.FileViewOpenFailed;
@@ -1103,7 +1103,7 @@ public class Sender implements RsyncTask,MessageHandler
                 "unable to decode path name of %s using %s",
                 fileInfo, _characterDecoder.charset()));
         }
-        Path relativePath = Paths.get(pathName);
+        Path relativePath = CustomFileSystem.getPath(pathName);
         return PathOps.subtractPath(fileInfo.path(), relativePath);
     }
 

--- a/src/main/com/github/perlundq/yajsync/session/ServerSessionConfig.java
+++ b/src/main/com/github/perlundq/yajsync/session/ServerSessionConfig.java
@@ -24,7 +24,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -34,6 +33,7 @@ import java.util.regex.Pattern;
 
 import com.github.perlundq.yajsync.channels.ChannelEOFException;
 import com.github.perlundq.yajsync.channels.ChannelException;
+import com.github.perlundq.yajsync.io.CustomFileSystem;
 import com.github.perlundq.yajsync.security.RsyncAuthContext;
 import com.github.perlundq.yajsync.text.Text;
 import com.github.perlundq.yajsync.text.TextConversionException;
@@ -333,7 +333,7 @@ public class ServerSessionConfig extends SessionConfig
                                       fileName));
                 }
                 Path safePath =
-                    _module.restrictedPath().resolve(Paths.get(fileName));
+                    _module.restrictedPath().resolve(CustomFileSystem.getPath(fileName));
                 if (Text.isNameDotDir(fileName)) {
                     safePath = safePath.resolve(PathOps.DOT_DIR);
                 }
@@ -349,7 +349,7 @@ public class ServerSessionConfig extends SessionConfig
                     unnamed, unnamed.size()));
             }
             String fileName = unnamed.get(0);
-            Path safePath = _module.restrictedPath().resolve(Paths.get(fileName));
+            Path safePath = _module.restrictedPath().resolve(CustomFileSystem.getPath(fileName));
             _receiverDestination = safePath.normalize();
 
             if (_log.isLoggable(Level.FINE)) {

--- a/src/main/com/github/perlundq/yajsync/ui/Configuration.java
+++ b/src/main/com/github/perlundq/yajsync/ui/Configuration.java
@@ -121,7 +121,7 @@ public class Configuration implements Modules
         {
             Map<String, Map<String, String>> modules;
             try (BufferedReader reader = Files.newBufferedReader(
-                                                   Paths.get(fileName),
+                                                   CustomFileSystem.getConfigPath(fileName),
                                                    Charset.defaultCharset())) {
                 modules = parse(reader);
             } catch (IOException e) {

--- a/src/main/com/github/perlundq/yajsync/ui/Configuration.java
+++ b/src/main/com/github/perlundq/yajsync/ui/Configuration.java
@@ -37,6 +37,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.github.perlundq.yajsync.io.CustomFileSystem;
 import com.github.perlundq.yajsync.session.Module;
 import com.github.perlundq.yajsync.session.ModuleException;
 import com.github.perlundq.yajsync.session.ModuleNotFoundException;
@@ -152,8 +153,8 @@ public class Configuration implements Modules
 
                 try {
                     RestrictedPath vp =
-                        new RestrictedPath(Paths.get(moduleName),
-                                           Paths.get(pathValue));
+                        new RestrictedPath(CustomFileSystem.getPath(moduleName),
+                        		CustomFileSystem.getPath(pathValue));
                     SimpleModule m = new SimpleModule(moduleName, vp);
                     String comment = Text.nullToEmptyStr(moduleContent.get(MODULE_KEY_COMMENT));
                     m._comment = comment;

--- a/src/main/com/github/perlundq/yajsync/ui/YajSyncClient.java
+++ b/src/main/com/github/perlundq/yajsync/ui/YajSyncClient.java
@@ -27,7 +27,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -43,6 +42,7 @@ import com.github.perlundq.yajsync.channels.net.ChannelFactory;
 import com.github.perlundq.yajsync.channels.net.DuplexByteChannel;
 import com.github.perlundq.yajsync.channels.net.SSLChannelFactory;
 import com.github.perlundq.yajsync.channels.net.StandardChannelFactory;
+import com.github.perlundq.yajsync.io.CustomFileSystem;
 import com.github.perlundq.yajsync.session.ClientSessionConfig;
 import com.github.perlundq.yajsync.session.RsyncClientSession;
 import com.github.perlundq.yajsync.session.RsyncException;
@@ -206,7 +206,7 @@ public class YajSyncClient implements ClientSessionConfig.AuthProvider
         private static String toLocalPathName(String pathName)
         {
             assert !pathName.isEmpty();
-            Path p = Paths.get(pathName);
+            Path p = CustomFileSystem.getPath(pathName);
             if (pathName.endsWith(Text.SLASH)) {
                 p = p.resolve(PathOps.DOT_DIR);  // Paths.get returns normalized path, any trailing slash is not preserved
             }
@@ -619,7 +619,7 @@ public class YajSyncClient implements ClientSessionConfig.AuthProvider
         localTransfer.setIsDeferredWrite(_isDeferredWrite);
         List<Path> srcPaths = new LinkedList<>();
         for (String pathName : _srcArgs) {
-            srcPaths.add(Paths.get(pathName));                                  // throws InvalidPathException
+            srcPaths.add(CustomFileSystem.getPath(pathName));                                  // throws InvalidPathException
         }
 
         try {

--- a/src/main/com/github/perlundq/yajsync/util/Environment.java
+++ b/src/main/com/github/perlundq/yajsync/util/Environment.java
@@ -22,10 +22,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 
+import com.github.perlundq.yajsync.io.CustomFileSystem;
 import com.github.perlundq.yajsync.text.Text;
 
 public final class Environment
@@ -99,7 +99,7 @@ public final class Environment
 
     public static Path getWorkingDirectory()
     {
-        return Paths.get(getNonNullProperty(PROPERTY_KEY_CWD));
+        return CustomFileSystem.getPath(getNonNullProperty(PROPERTY_KEY_CWD));
     }
 
     public static String getServerConfig(String defName)

--- a/src/main/com/github/perlundq/yajsync/util/FileOps.java
+++ b/src/main/com/github/perlundq/yajsync/util/FileOps.java
@@ -267,7 +267,11 @@ public class FileOps
     public static boolean atomicMove(Path tempFile, Path path)
     {
         try {
-            Files.move(tempFile, path, StandardCopyOption.ATOMIC_MOVE);
+            if (tempFile.getFileSystem().equals(path.getFileSystem())) {
+                Files.move(tempFile, path, StandardCopyOption.ATOMIC_MOVE);
+            } else {
+            	Files.move(tempFile, path, StandardCopyOption.REPLACE_EXISTING);
+            }
             return true;
         } catch (IOException e) {
             return false;

--- a/src/main/com/github/perlundq/yajsync/util/PathOps.java
+++ b/src/main/com/github/perlundq/yajsync/util/PathOps.java
@@ -20,17 +20,17 @@ package com.github.perlundq.yajsync.util;
 
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.github.perlundq.yajsync.io.CustomFileSystem;
 import com.github.perlundq.yajsync.text.Text;
 
 public final class PathOps
 {
-    public static final Path EMPTY = Paths.get(Text.EMPTY);
-    public static final Path DOT_DIR = Paths.get(Text.DOT);
-    public static final Path DOT_DOT_DIR = Paths.get(Text.DOT_DOT);
+    public static final Path EMPTY = CustomFileSystem.getPath(Text.EMPTY);
+    public static final Path DOT_DIR = CustomFileSystem.getPath(Text.DOT);
+    public static final Path DOT_DOT_DIR = CustomFileSystem.getPath(Text.DOT_DOT);
 
     private PathOps() {}
 
@@ -166,7 +166,7 @@ public final class PathOps
                 String normalized =
                     Text.deleteTrailingDots(p.toString()).toLowerCase();
                 if (!normalized.isEmpty()) {
-                    paths.add(Paths.get(normalized));
+                    paths.add(CustomFileSystem.getPath(normalized));
                 }
             }
         }
@@ -197,8 +197,8 @@ public final class PathOps
     public static Path get(String name)
     {
         if (name.endsWith(Text.SLASH)) {
-            return Paths.get(name + Text.DOT);
+            return CustomFileSystem.getPath(name + Text.DOT);
         }
-        return Paths.get(name);
+        return CustomFileSystem.getPath(name);
     }
 }


### PR DESCRIPTION
In reference to https://github.com/perlundq/yajsync/issues/17 I propose the following changes:

- optionally configurable FileSystems for file storage and temporary files

- use SeekableByteChannel instead of FileChannel for a more common implementation

- change atomicMove to support different FileSystems (from/to)