### PR TITLE
Don't map uid/gid values by user/group name (--numeric-ids)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Currently implemented rsync options:
 
 - Preserve owner (-o, --owner)
 
+- Don't map uid/gid values by user/group name (--numeric-ids)
+
 - Preserve permissions (-p, --perms)
 
 - Preserve times (-t, --times)

--- a/src/main/com/github/perlundq/yajsync/RsyncClient.java
+++ b/src/main/com/github/perlundq/yajsync/RsyncClient.java
@@ -168,6 +168,7 @@ public final class RsyncClient
                                 isPreservePermissions(_isPreservePermissions).
                                 isPreserveTimes(_isPreserveTimes).
                                 isPreserveUser(_isPreserveUser).
+                                isNumericIds(_isNumericIds).
                                 isIgnoreTimes(_isIgnoreTimes).
                                 isAlwaysItemize(_verbosity > 1).
                                 isListOnly(true).
@@ -364,6 +365,7 @@ public final class RsyncClient
                     isExitEarlyIfEmptyList(true).
                     charset(_charset).
                     isPreserveUser(_isPreserveUser).
+                    isNumericIds(_isNumericIds).
                     fileSelection(fileSelection).build();
             Generator generator = new Generator.Builder(toSender.sink(), seed).
                     charset(_charset).
@@ -371,6 +373,7 @@ public final class RsyncClient
                     isPreservePermissions(_isPreservePermissions).
                     isPreserveTimes(_isPreserveTimes).
                     isPreserveUser(_isPreserveUser).
+                    isNumericIds(_isNumericIds).
                     isIgnoreTimes(_isIgnoreTimes).
                     isListOnly(true).
                     isAlwaysItemize(_isAlwaysItemize).build();
@@ -410,6 +413,7 @@ public final class RsyncClient
                     isExitEarlyIfEmptyList(true).
                     charset(_charset).
                     isPreserveUser(_isPreserveUser).
+                    isNumericIds(_isNumericIds).
                     fileSelection(fileSelection).build();
             Generator generator = new Generator.Builder(toSender.sink(), seed).
                     charset(_charset).
@@ -417,6 +421,7 @@ public final class RsyncClient
                     isPreservePermissions(_isPreservePermissions).
                     isPreserveTimes(_isPreserveTimes).
                     isPreserveUser(_isPreserveUser).
+                    isNumericIds(_isNumericIds).
                     isIgnoreTimes(_isIgnoreTimes).
                     isListOnly(false).
                     isAlwaysItemize(_isAlwaysItemize).build();
@@ -628,6 +633,10 @@ public final class RsyncClient
             // revisit if we add support for --iconv
             serverArgs.add(sb.toString());
 
+			if (_isNumericIds) {
+				serverArgs.add("--numeric-ids");
+			}
+
             serverArgs.add("."); // arg delimiter
 
             if (mode == Mode.REMOTE_SEND) {
@@ -693,6 +702,7 @@ public final class RsyncClient
                             isPreservePermissions(_isPreservePermissions).
                             isPreserveTimes(_isPreserveTimes).
                             isPreserveUser(_isPreserveUser).
+                            isNumericIds(_isNumericIds).
                             isIgnoreTimes(_isIgnoreTimes).
                             isAlwaysItemize(_verbosity > 1).
                             isListOnly(mode == Mode.REMOTE_LIST).
@@ -765,6 +775,7 @@ public final class RsyncClient
         private boolean _isDeferWrite;
         private boolean _isIgnoreTimes;
         private boolean _isPreserveUser;
+        private boolean _isNumericIds;
         private boolean _isPreservePermissions;
         private boolean _isPreserveTimes;
         private Charset _charset = Charset.forName(Text.UTF8_NAME);
@@ -812,6 +823,12 @@ public final class RsyncClient
         public Builder isPreserveUser(boolean isPreserveUser)
         {
             _isPreserveUser = isPreserveUser;
+            return this;
+        }
+
+        public Builder isNumericIds(boolean isNumericIds)
+        {
+            _isNumericIds = isNumericIds;
             return this;
         }
 
@@ -873,6 +890,7 @@ public final class RsyncClient
     private final boolean _isIgnoreTimes;
     private final boolean _isOwnerOfExecutorService;
     private final boolean _isPreserveUser;
+    private final boolean _isNumericIds;
     private final boolean _isPreservePermissions;
     private final boolean _isPreserveTimes;
     private final Charset _charset;
@@ -890,6 +908,7 @@ public final class RsyncClient
         _isDeferWrite = builder._isDeferWrite;
         _isIgnoreTimes = builder._isIgnoreTimes;
         _isPreserveUser = builder._isPreserveUser;
+        _isNumericIds = builder._isNumericIds;
         _isPreservePermissions = builder._isPreservePermissions;
         _isPreserveTimes = builder._isPreserveTimes;
         _charset = builder._charset;

--- a/src/main/com/github/perlundq/yajsync/RsyncClient.java
+++ b/src/main/com/github/perlundq/yajsync/RsyncClient.java
@@ -726,6 +726,7 @@ public final class RsyncClient
                             charset(_charset).
                             fileSelection(fileSelection).
                             isPreserveUser(_isPreserveUser).
+                            isNumericIds(_isNumericIds).
                             isInterruptible(_isInterruptible).
                             isSafeFileList(cfg.isSafeFileList()).build();
                     isOK = _rsyncTaskExecutor.exec(sender);

--- a/src/main/com/github/perlundq/yajsync/RsyncServer.java
+++ b/src/main/com/github/perlundq/yajsync/RsyncServer.java
@@ -22,6 +22,7 @@ package com.github.perlundq.yajsync;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.concurrent.ExecutorService;
 
 import com.github.perlundq.yajsync.session.Generator;
@@ -109,6 +110,7 @@ public class RsyncServer
                     charset(cfg.charset()).
                     fileSelection(cfg.fileSelection()).
                     isPreserveUser(cfg.isPreserveUser()).
+                    isNumericIds(cfg.isNumericIds()).
                     isInterruptible(isChannelsInterruptible).
                     isSafeFileList(cfg.isSafeFileList()).build();
             return _rsyncTaskExecutor.exec(sender);
@@ -120,6 +122,7 @@ public class RsyncServer
                     isPreservePermissions(cfg.isPreservePermissions()).
                     isPreserveTimes(cfg.isPreserveTimes()).
                     isPreserveUser(cfg.isPreserveUser()).
+                    isNumericIds(cfg.isNumericIds()).
                     isIgnoreTimes(cfg.isIgnoreTimes()).
                     isAlwaysItemize(cfg.verbosity() > 1).
                     isInterruptible(isChannelsInterruptible).build();

--- a/src/main/com/github/perlundq/yajsync/session/Generator.java
+++ b/src/main/com/github/perlundq/yajsync/session/Generator.java
@@ -75,6 +75,7 @@ public class Generator implements RsyncTask, Iterable<FileInfo>
         private boolean _isPreservePermissions;
         private boolean _isPreserveTimes;
         private boolean _isPreserveUser;
+        private boolean _isNumericIds;
         private Charset _charset;
         private FileSelection _fileSelection = FileSelection.EXACT;
 
@@ -128,6 +129,12 @@ public class Generator implements RsyncTask, Iterable<FileInfo>
             return this;
         }
 
+        public Builder isNumericIds(boolean isNumericIds)
+        {
+            _isNumericIds = isNumericIds;
+            return this;
+        }
+
         public Builder charset(Charset charset)
         {
             assert charset != null;
@@ -166,6 +173,7 @@ public class Generator implements RsyncTask, Iterable<FileInfo>
     private final boolean _isPreservePermissions;
     private final boolean _isPreserveTimes;
     private final boolean _isPreserveUser;
+    private final boolean _isNumericIds;
     private final byte[] _checksumSeed;
     private final Deque<Runnable> _deferredFileAttrUpdates = new ArrayDeque<>();
     private final Filelist _fileList;
@@ -205,6 +213,7 @@ public class Generator implements RsyncTask, Iterable<FileInfo>
         _isPreservePermissions = builder._isPreservePermissions;
         _isPreserveTimes = builder._isPreserveTimes;
         _isPreserveUser = builder._isPreserveUser;
+        _isNumericIds = builder._isNumericIds;
     }
 
     @Override
@@ -237,6 +246,11 @@ public class Generator implements RsyncTask, Iterable<FileInfo>
     public boolean isPreserveUser()
     {
         return _isPreserveUser;
+    }
+
+    public boolean isNumericIds()
+    {
+        return _isNumericIds;
     }
 
     public Charset charset()
@@ -845,35 +859,36 @@ public class Generator implements RsyncTask, Iterable<FileInfo>
         //       succeed).
         // NOTE: we cannot detect if we have the capabilities to change
         //       ownership (knowing if UID 0 is not sufficient)
-        // TODO: fall back to changing uid (find out how rsync works) if name
-        //       change fails
-        if (_isPreserveUser && !newAttrs.user().name().isEmpty() &&
-            (curAttrsOrNull == null ||
-             !curAttrsOrNull.user().name().equals(newAttrs.user().name())))
-        {
-            if (_log.isLoggable(Level.FINE)) {
-                _log.fine(String.format(
-                    "(Generator) updating ownership %s -> %s on %s",
-                    curAttrsOrNull == null ? "" : curAttrsOrNull.user(),
-                    newAttrs.user(), path));
+        if (_isPreserveUser) {
+            if (!_isNumericIds && !newAttrs.user().name().isEmpty()
+                    && (curAttrsOrNull == null || !curAttrsOrNull.user().name()
+                            .equals(newAttrs.user().name()))) {
+                if (_log.isLoggable(Level.FINE)) {
+                    _log.fine(String
+                            .format("(Generator) updating ownership %s -> %s on %s",
+                                    curAttrsOrNull == null ? ""
+                                            : curAttrsOrNull.user(),
+                                    newAttrs.user(), path));
+                }
+                // NOTE: side effect of chown in Linux is that set user/group id
+                // bit might be cleared.
+                FileOps.setOwner(path, newAttrs.user(),
+                        LinkOption.NOFOLLOW_LINKS);
+            } else if ((_isNumericIds || newAttrs.user().name().isEmpty())
+                    && (curAttrsOrNull == null || curAttrsOrNull.user()
+                            .uid() != newAttrs.user().uid())) {
+                if (_log.isLoggable(Level.FINE)) {
+                    _log.fine(String.format(
+                            "(Generator) updating uid %s -> %d on %s",
+                            curAttrsOrNull == null ? ""
+                                    : curAttrsOrNull.user().uid(),
+                            newAttrs.user().uid(), path));
+                }
+                // NOTE: side effect of chown in Linux is that set user/group id
+                // bit might be cleared.
+                FileOps.setUserId(path, newAttrs.user().uid(),
+                        LinkOption.NOFOLLOW_LINKS);
             }
-            // NOTE: side effect of chown in Linux is that set user/group id bit
-            //       might be cleared.
-            FileOps.setOwner(path, newAttrs.user(),
-                             LinkOption.NOFOLLOW_LINKS);
-        } else if (_isPreserveUser && newAttrs.user().name().isEmpty() &&
-                   (curAttrsOrNull == null ||
-                    curAttrsOrNull.user().uid() != newAttrs.user().uid())) {
-            if (_log.isLoggable(Level.FINE)) {
-                _log.fine(String.format(
-                    "(Generator) updating uid %s -> %d on %s",
-                    curAttrsOrNull == null ? "" : curAttrsOrNull.user().uid(),
-                    newAttrs.user().uid(), path));
-            }
-            // NOTE: side effect of chown in Linux is that set user/group id bit
-            //       might be cleared.
-            FileOps.setUserId(path, newAttrs.user().uid(),
-                              LinkOption.NOFOLLOW_LINKS);
         }
     }
 

--- a/src/main/com/github/perlundq/yajsync/session/Receiver.java
+++ b/src/main/com/github/perlundq/yajsync/session/Receiver.java
@@ -204,6 +204,7 @@ public class Receiver implements RsyncTask, MessageHandler
     private final boolean _isPreservePermissions;
     private final boolean _isPreserveTimes;
     private final boolean _isPreserveUser;
+    private final boolean _isNumericIds;
     private final boolean _isReceiveStatistics;
     private final boolean _isSafeFileList;
     private final boolean _isSendFilterRules;
@@ -233,6 +234,7 @@ public class Receiver implements RsyncTask, MessageHandler
         _isPreservePermissions = _generator.isPreservePermissions();
         _isPreserveTimes = _generator.isPreserveTimes();
         _isPreserveUser = _generator.isPreserveUser();
+        _isNumericIds = _generator.isNumericIds();
         _fileSelection = _generator.fileSelection();
         _in = new RsyncInChannel(builder._in, this, INPUT_CHANNEL_BUF_SIZE);
         _targetPathName = builder._targetPathName;
@@ -279,10 +281,12 @@ public class Receiver implements RsyncTask, MessageHandler
             List<FileInfoStub> stubs = new LinkedList<>();
             _ioError |= receiveFileMetaDataInto(stubs);
 
-            if (_isPreserveUser && _fileSelection != FileSelection.RECURSE) {
-                Map<Integer, User> uidUserMap = receiveUserList();
-                uidUserMap.put(User.root().uid(), User.root());
-                addUserNameToStubs(uidUserMap, stubs);
+            if (!_isNumericIds && _fileSelection != FileSelection.RECURSE) {
+                if (_isPreserveUser) {
+                    Map<Integer, User> uidUserMap = receiveUserList();
+                    uidUserMap.put(User.root().uid(), User.root());
+                    addUserNameToStubs(uidUserMap, stubs);
+                }
             }
 
             if (stubs.size() == 0 && _isExitEarlyIfEmptyList) {
@@ -725,7 +729,7 @@ public class Receiver implements RsyncTask, MessageHandler
                 if (!Item.isValidItem(iFlags)) {
                     throw new IllegalStateException(String.format(
                             "got flags %s - not supported",
-                            Integer.toBinaryString((int) iFlags)));
+                            Integer.toBinaryString(iFlags)));
                 }
 
                 if ((iFlags & Item.TRANSFER) == 0) {
@@ -849,29 +853,30 @@ public class Receiver implements RsyncTask, MessageHandler
             FileOps.setLastModifiedTime(path, targetAttrs.lastModifiedTime(),
                                         LinkOption.NOFOLLOW_LINKS);
         }
-        if (_isPreserveUser && !targetAttrs.user().name().isEmpty() &&
-            !curAttrs.user().name().equals(targetAttrs.user().name())) {
-            if (_log.isLoggable(Level.FINE)) {
-                _log.fine(String.format("updating ownership %s -> %s on %s",
-                                        curAttrs.user(), targetAttrs.user(),
-                                        path));
+        if (_isPreserveUser) {
+            if (!_isNumericIds && !targetAttrs.user().name().isEmpty()
+                    && !curAttrs.user().name()
+                    .equals(targetAttrs.user().name())) {
+                if (_log.isLoggable(Level.FINE)) {
+                    _log.fine(String.format("updating ownership %s -> %s on %s",
+                            curAttrs.user(), targetAttrs.user(), path));
+                }
+                // FIXME: side effect of chown in Linux is that set user/group
+                // id bit are cleared.
+                FileOps.setOwner(path, targetAttrs.user(),
+                        LinkOption.NOFOLLOW_LINKS);
+            } else if ((_isNumericIds || targetAttrs.user().name().isEmpty())
+                    && curAttrs.user().uid() != targetAttrs.user().uid()) {
+                if (_log.isLoggable(Level.FINE)) {
+                    _log.fine(String.format("updating uid %d -> %d on %s",
+                            curAttrs.user().uid(), targetAttrs.user().uid(),
+                            path));
+                }
+                // NOTE: side effect of chown in Linux is that set user/group id
+                // bit might be cleared.
+                FileOps.setUserId(path, targetAttrs.user().uid(),
+                        LinkOption.NOFOLLOW_LINKS);
             }
-            // FIXME: side effect of chown in Linux is that set user/group id
-            //        bit are cleared.
-            FileOps.setOwner(path, targetAttrs.user(),
-                             LinkOption.NOFOLLOW_LINKS);
-        } else if (_isPreserveUser && targetAttrs.user().name().isEmpty() &&
-             curAttrs.user().uid() != targetAttrs.user().uid())
-        {
-            if (_log.isLoggable(Level.FINE)) {
-                _log.fine(String.format("updating uid %d -> %d on %s",
-                                        curAttrs.user().uid(),
-                                        targetAttrs.user().uid(), path));
-            }
-            // NOTE: side effect of chown in Linux is that set user/group id bit
-            //       might be cleared.
-            FileOps.setUserId(path, targetAttrs.user().uid(),
-                              LinkOption.NOFOLLOW_LINKS);
         }
     }
 

--- a/src/main/com/github/perlundq/yajsync/session/Sender.java
+++ b/src/main/com/github/perlundq/yajsync/session/Sender.java
@@ -79,6 +79,7 @@ public final class Sender implements RsyncTask, MessageHandler
         private boolean _isExitEarlyIfEmptyList;
         private boolean _isInterruptible = true;
         private boolean _isPreserveUser;
+        private boolean _isNumericIds;
         private boolean _isReceiveFilterRules;
         private boolean _isSafeFileList = true;
         private boolean _isSendStatistics;
@@ -140,6 +141,12 @@ public final class Sender implements RsyncTask, MessageHandler
             return this;
         }
 
+        public Builder isNumericIds(boolean isNumericIds)
+        {
+            _isNumericIds = isNumericIds;
+            return this;
+        }
+
         public Builder charset(Charset charset)
         {
             assert charset != null;
@@ -184,6 +191,7 @@ public final class Sender implements RsyncTask, MessageHandler
     private final boolean _isExitEarlyIfEmptyList;
     private final boolean _isInterruptible;
     private final boolean _isPreserveUser;
+    private final boolean _isNumericIds;
     private final boolean _isReceiveFilterRules;
     private final boolean _isSafeFileList;
     private final boolean _isSendStatistics;
@@ -211,6 +219,7 @@ public final class Sender implements RsyncTask, MessageHandler
         _isExitEarlyIfEmptyList = builder._isExitEarlyIfEmptyList;
         _isInterruptible = builder._isInterruptible;
         _isPreserveUser = builder._isPreserveUser;
+        _isNumericIds = builder._isNumericIds;
         _isReceiveFilterRules = builder._isReceiveFilterRules;
         _isSafeFileList = builder._isSafeFileList;
         _isSendStatistics = builder._isSendStatistics;
@@ -276,7 +285,8 @@ public final class Sender implements RsyncTask, MessageHandler
             }
             long t3 = System.currentTimeMillis();
 
-            if (_isPreserveUser && _fileSelection != FileSelection.RECURSE) {
+            if (_isPreserveUser && !_isNumericIds
+                    && _fileSelection != FileSelection.RECURSE) {
                 sendUserList();
             }
 
@@ -536,7 +546,7 @@ public final class Sender implements RsyncTask, MessageHandler
                 if (!Item.isValidItem(iFlags)) {
                     throw new IllegalStateException(String.format(
                         "got flags %s - not supported",
-                        Integer.toBinaryString((int) iFlags)));
+                        Integer.toBinaryString(iFlags)));
                 }
                 if ((iFlags & Item.TRANSFER) == 0) {
                     if (segment == null ||
@@ -1062,7 +1072,7 @@ public final class Sender implements RsyncTask, MessageHandler
         if (!Item.isValidItem(iFlags)) {
             throw new IllegalStateException(String.format(
                     "got flags %s - not supported",
-                    Integer.toBinaryString((int) iFlags)));
+                    Integer.toBinaryString(iFlags)));
         }
         _duplexChannel.encodeIndex(index);
         _duplexChannel.putChar(iFlags);

--- a/src/main/com/github/perlundq/yajsync/session/ServerSessionConfig.java
+++ b/src/main/com/github/perlundq/yajsync/session/ServerSessionConfig.java
@@ -58,6 +58,7 @@ public class ServerSessionConfig extends SessionConfig
     private boolean _isPreservePermissions = false;
     private boolean _isPreserveTimes = false;
     private boolean _isPreserveUser = false;
+    private boolean _isNumericIds = false;
     private boolean _isIgnoreTimes = false;
     private FileSelection _fileSelection = FileSelection.EXACT;
     private Module _module;
@@ -309,6 +310,14 @@ public class ServerSessionConfig extends SessionConfig
 
         argsParser.add(Option.newWithoutArgument(
             Option.Policy.OPTIONAL,
+            "numeric-ids", "", "",
+            new Option.ContinuingHandler() {
+                @Override public void handleAndContinue(Option option) {
+                    setIsNumericIds();
+                }}));
+
+        argsParser.add(Option.newWithoutArgument(
+            Option.Policy.OPTIONAL,
             "perms", "p", "",
             new Option.ContinuingHandler() {
                 @Override public void handleAndContinue(Option option) {
@@ -322,7 +331,6 @@ public class ServerSessionConfig extends SessionConfig
                 @Override public void handleAndContinue(Option option) {
                     setIsPreserveTimes();
                 }}));
-
 
         argsParser.add(Option.newWithoutArgument(
             Option.Policy.OPTIONAL,
@@ -457,6 +465,11 @@ public class ServerSessionConfig extends SessionConfig
         _isPreserveUser = true;
     }
 
+    private void setIsNumericIds()
+    {
+        _isNumericIds = true;
+    }
+
     private void setIsIgnoreTimes()
     {
         _isIgnoreTimes = true;
@@ -485,6 +498,11 @@ public class ServerSessionConfig extends SessionConfig
     public boolean isPreserveUser()
     {
         return _isPreserveUser;
+    }
+
+    public boolean isNumericIds()
+    {
+        return _isNumericIds;
     }
 
     public boolean isIgnoreTimes()

--- a/src/main/com/github/perlundq/yajsync/ui/YajSyncClient.java
+++ b/src/main/com/github/perlundq/yajsync/ui/YajSyncClient.java
@@ -135,7 +135,7 @@ public class YajSyncClient
     private int _verbosity;
     private PrintStream _stderr = System.out;
     private PrintStream _stdout = System.out;
-    private RsyncClient.Builder _clientBuilder =
+    private final RsyncClient.Builder _clientBuilder =
             new RsyncClient.Builder().authProvider(_authProvider);
     private Statistics _statistics = new Statistics();
     private String _passwordFile;
@@ -265,6 +265,17 @@ public class YajSyncClient
             new Option.ContinuingHandler() {
                 @Override public void handleAndContinue(Option option) {
                     _clientBuilder.isPreserveUser(true);
+                }}));
+
+        options.add(
+            Option.newWithoutArgument(Option.Policy.OPTIONAL,
+                                      "numeric-ids", "",
+                                      String.format("don't map uid/gid " +
+                                              "values by user/group name " +
+                                              "(default false)"),
+            new Option.ContinuingHandler() {
+                @Override public void handleAndContinue(Option option) {
+                    _clientBuilder.isNumericIds(true);
                 }}));
 
         options.add(


### PR DESCRIPTION
The documentation comprises grid/group (for compat. reasons). In the next step there will be a pull request based on the numeric-ids branch to merge in the gid/group extension.
The system test named "testClientCopyPreserveUid" requires to be executed as 'root'. I propose to just skip the test when user!=root. Currently the test fails if superuser privileges are not available.
Scripts like http://stackoverflow.com/questions/2580279/how-do-i-run-my-application-as-superuser-from-eclipse simplifies the execution as root in an IDE.