### PR TITLE
Add rsync timeout options (--timeout and --contimeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Currently implemented rsync options:
 
 - Archive mode (-a, --archive)
 
+- Set I/O timeout in seconds (--timeout=SECONDS)
+
+- Set daemon connection timeout in seconds (--contimeout=SECONDS)
+
 Simulated options:
 
 - Preserve character device files and block device files (--devices)

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/ChannelFactory.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/ChannelFactory.java
@@ -20,5 +20,5 @@ import java.io.IOException;
 
 public interface ChannelFactory
 {
-    DuplexByteChannel open(String address, int remotePort) throws IOException;
+    DuplexByteChannel open(String address, int remotePort, int contimeout, int timeout) throws IOException;
 }

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/SSLChannel.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/SSLChannel.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.security.Principal;
@@ -39,20 +40,23 @@ public class SSLChannel implements DuplexByteChannel
     private final OutputStream _os;
     private final SSLSocket _sslSocket;
 
-    public SSLChannel(SSLSocket sslSocket) throws IOException
+    public SSLChannel(SSLSocket sslSocket, int timeout) throws IOException
     {
         assert Environment.hasAllocateDirectArray() ||
                !Environment.isAllocateDirect();
         _sslSocket = sslSocket;
+        _sslSocket.setSoTimeout(timeout * 1000);
         _is = _sslSocket.getInputStream();
         _os = _sslSocket.getOutputStream();
     }
 
-    public static SSLChannel open(String address, int port) throws IOException
+    public static SSLChannel open(String address, int port, int contimeout, int timeout) throws IOException
     {
         SocketFactory factory = SSLSocketFactory.getDefault();
-        Socket sock = factory.createSocket(address, port);
-        return new SSLChannel((SSLSocket) sock);
+        InetSocketAddress socketAddress = new InetSocketAddress(address, port);
+        Socket sock = factory.createSocket();
+        sock.connect(socketAddress, contimeout * 1000);
+        return new SSLChannel((SSLSocket) sock, timeout);
     }
 
     @Override

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/SSLChannelFactory.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/SSLChannelFactory.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 public class SSLChannelFactory implements ChannelFactory
 {
     @Override
-    public DuplexByteChannel open(String address, int port)
+    public DuplexByteChannel open(String address, int port, int contimeout, int timeout)
         throws IOException
     {
-        return SSLChannel.open(address, port);
+        return SSLChannel.open(address, port, contimeout, timeout);
     }
 }

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/SSLServerChannel.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/SSLServerChannel.java
@@ -24,10 +24,12 @@ import javax.net.ssl.SSLSocket;
 public class SSLServerChannel implements ServerChannel
 {
     private final SSLServerSocket _sslSocket;
+    private final int _timeout;
 
-    public SSLServerChannel(SSLServerSocket sock)
+    public SSLServerChannel(SSLServerSocket sock, int timeout)
     {
         _sslSocket = sock;
+        _timeout = timeout;
     }
 
     @Override
@@ -39,6 +41,6 @@ public class SSLServerChannel implements ServerChannel
     @Override
     public SSLChannel accept() throws IOException
     {
-        return new SSLChannel((SSLSocket) _sslSocket.accept());
+        return new SSLChannel((SSLSocket) _sslSocket.accept(), _timeout);
     }
 }

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/SSLServerChannelFactory.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/SSLServerChannelFactory.java
@@ -55,7 +55,7 @@ public class SSLServerChannelFactory implements ServerChannelFactory
     }
 
     @Override
-    public ServerChannel open(InetAddress address, int port) throws IOException
+    public ServerChannel open(InetAddress address, int port, int timeout) throws IOException
     {
         SSLServerSocket sock =
             (SSLServerSocket) _factory.createServerSocket(port,
@@ -63,7 +63,7 @@ public class SSLServerChannelFactory implements ServerChannelFactory
         try {
             sock.setReuseAddress(_isReuseAddress);
             sock.setWantClientAuth(_isWantClientAuth);
-            return new SSLServerChannel(sock);
+            return new SSLServerChannel(sock, timeout);
         } catch (Throwable t) {
             if (!sock.isClosed()) {
                 try {

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/ServerChannelFactory.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/ServerChannelFactory.java
@@ -22,5 +22,5 @@ import java.net.InetAddress;
 public interface ServerChannelFactory
 {
     ServerChannelFactory setReuseAddress(boolean isReuseAddress);
-    ServerChannel open(InetAddress address, int port) throws IOException;
+    ServerChannel open(InetAddress address, int port, int timeout) throws IOException;
 }

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/StandardChannelFactory.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/StandardChannelFactory.java
@@ -17,18 +17,13 @@
 package com.github.perlundq.yajsync.channels.net;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.nio.channels.SocketChannel;
 
 public class StandardChannelFactory implements ChannelFactory
 {
     @Override
-    public DuplexByteChannel open(String address, int remotePort)
+    public DuplexByteChannel open(String address, int port, int contimeout, int timeout)
         throws IOException
     {
-        InetSocketAddress socketAddress = new InetSocketAddress(address,
-                                                                remotePort);
-        SocketChannel socket = SocketChannel.open(socketAddress);
-        return new StandardSocketChannel(socket);
+        return StandardSocketChannel.open(address, port, contimeout, timeout);
     }
 }

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/StandardServerChannel.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/StandardServerChannel.java
@@ -22,10 +22,12 @@ import java.nio.channels.ServerSocketChannel;
 public class StandardServerChannel implements ServerChannel
 {
     private final ServerSocketChannel _sock;
+    private final int _timeout;
 
-    public StandardServerChannel(ServerSocketChannel sock)
+    public StandardServerChannel(ServerSocketChannel sock, int timeout)
     {
         _sock = sock;
+        _timeout = timeout;
     }
 
     @Override
@@ -37,6 +39,6 @@ public class StandardServerChannel implements ServerChannel
     @Override
     public StandardSocketChannel accept() throws IOException
     {
-        return new StandardSocketChannel(_sock.accept());
+        return new StandardSocketChannel(_sock.accept(), _timeout);
     }
 }

--- a/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/StandardServerChannelFactory.java
+++ b/yajsync-core/src/main/java/com/github/perlundq/yajsync/channels/net/StandardServerChannelFactory.java
@@ -34,7 +34,7 @@ public class StandardServerChannelFactory implements ServerChannelFactory
     }
 
     @Override
-    public ServerChannel open(InetAddress address, int port) throws IOException
+    public ServerChannel open(InetAddress address, int port, int timeout) throws IOException
     {
         ServerSocketChannel sock = ServerSocketChannel.open();
         try {
@@ -44,7 +44,7 @@ public class StandardServerChannelFactory implements ServerChannelFactory
             InetSocketAddress socketAddress =
                 new InetSocketAddress(address, port);
             sock.bind(socketAddress);
-            return new StandardServerChannel(sock);
+            return new StandardServerChannel(sock, timeout);
         } catch (Throwable t) {
             try {
                 if (sock.isOpen()) {


### PR DESCRIPTION
This change refers to connection timeouts of clients (tls/non-tls) to server as well as i/o timeouts of client and server in tls and non-tls mode. SSLChannel and StandardChannel were being unified. When timeouts are enabled socket communication uses non-blocking SocketChannel/SocketAdapter methods to allow the setting and processing of timeouts. In this scenario direct buffers are disabled.

SystemTest was extended to test basic Channel connect/read/write operations with timeouts.